### PR TITLE
Machine key store support

### DIFF
--- a/src/Mews.Eet.Tests/IntegrationTests/Basics.cs
+++ b/src/Mews.Eet.Tests/IntegrationTests/Basics.cs
@@ -27,7 +27,6 @@ namespace Mews.Eet.Tests.IntegrationTests
         [Fact]
         public async Task TimeoutWorks()
         {
-
             var certificate = CreateCertificate(Fixtures.Second);
             var record = CreateSimpleRecord(certificate, Fixtures.Second);
             var client = new EetClient(certificate, EetEnvironment.Playground, TimeSpan.FromMilliseconds(1));

--- a/src/Mews.Eet/Dto/Certificate.cs
+++ b/src/Mews.Eet/Dto/Certificate.cs
@@ -20,10 +20,10 @@ namespace Mews.Eet.Dto
         {
             if (useMachineKeyStore)
             {
-                return X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet;
+                return X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet;
             }
 
-            return X509KeyStorageFlags.Exportable;
+            return X509KeyStorageFlags.DefaultKeySet;
         }
     }
 }

--- a/src/Mews.Eet/Dto/Certificate.cs
+++ b/src/Mews.Eet/Dto/Certificate.cs
@@ -6,14 +6,24 @@ namespace Mews.Eet.Dto
 {
     public class Certificate
     {
-        public Certificate(string password, byte[] data)
+        public Certificate(string password, byte[] data, bool useMachineKeyStore = false)
         {
-            X509Certificate2 = new X509Certificate2(data, password, X509KeyStorageFlags.DefaultKeySet);
+            X509Certificate2 = new X509Certificate2(data, password, GetKeyStorageFlags(useMachineKeyStore));
             PrivateKey = X509Certificate2.GetRSAPrivateKey() ?? throw new ArgumentException("The provided certificate does not have an RSA key.");
         }
 
         public RSA PrivateKey { get; }
 
         public X509Certificate2 X509Certificate2 { get; }
+
+        private X509KeyStorageFlags GetKeyStorageFlags(bool useMachineKeyStore)
+        {
+            if (useMachineKeyStore)
+            {
+                return X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet;
+            }
+
+            return X509KeyStorageFlags.Exportable;
+        }
     }
 }


### PR DESCRIPTION
We deleted `userMachineKeyStore` support in #43, but this makes it unusable on some configurations of Azure App Service. It's now back.
